### PR TITLE
Remove duplicate roots in permalink of post

### DIFF
--- a/lib/models/post.js
+++ b/lib/models/post.js
@@ -57,7 +57,7 @@ module.exports = function(ctx) {
   Post.virtual('permalink').get(function() {
     var config = ctx.config;
 
-    return config.url + config.root + this.path;
+    return config.url + '/' + this.path;
   });
 
   Post.virtual('full_source').get(function() {


### PR DESCRIPTION
Currently the wrong permalink is reported in `post.permalink` and the root is duplicated twice.

If I am correct, as per documentation:
- `config.url` - full path wthout trailing slash
- `this.path` - as per console logging is the relative path

Thus the permalink should be `config.url + '/' + this.path`.

Fixes #2048
